### PR TITLE
Make searching optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ db/
 
 # test db files
 *.scdb
+*.iscdb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [0.2.0] - 2023-01-16
+
+### Added
+
+### Changed
+
+- Changed the `scdb.New()` signature, replacing `maxIndexKeyLen` option with `isSearchEnabled`.
+- Permanently set the maximum index key length to 3
+- Changed benchmarks to compare operations when search is enabled to when search is disabled.
+
+### Fixed
+
 ## [0.1.0] - 2023-01-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ little more appealing, it has some extra features like:
 - Time-to-live (TTL) where a key-value pair expires after a given time
 - Non-blocking reads from separate processes, and threads.
 - Fast Sequential writes to the store, queueing any writes from multiple processes and threads.
+- Optional searching of keys that begin with a given subsequence. This option is turned on when `scdb.New()` is called.
+  Note: **`Delete`, `Set`, `Clear`, `Compact` are considerably slower when searching is enabled.**
 
 ## Dependencies
 
@@ -81,7 +83,6 @@ func main() {
 	var redundantBlocks uint16 = 1
 	var poolCapacity uint64 = 10
 	var compactionInterval uint32 = 1_800
-	var maxIndexKeyLen uint32 = 3
 
 	store, err := scdb.New(
 		"db",
@@ -89,7 +90,7 @@ func main() {
 		&redundantBlocks,
 		&poolCapacity,
 		&compactionInterval,
-		&maxIndexKeyLen)
+		true)
 	if err != nil {
 		log.Fatalf("error opening store: %s", err)
 	}
@@ -238,77 +239,120 @@ On a average PC
 
 ``` 
 cpu: Intel(R) Core(TM) i7-4870HQ CPU @ 2.50GHz
-BenchmarkStore_Clear/Clear-8                       12363            126526 ns/op
-BenchmarkStore_Clear/Clear_with_ttl:_3600-8                13052             89014 ns/op
-BenchmarkStore_Compact/Compact-8                              52          23302258 ns/op
-BenchmarkStore_DeleteWithoutTtl/Delete_key_hey-8          505140              3094 ns/op
-BenchmarkStore_DeleteWithoutTtl/Delete_key_hi-8           245188              4587 ns/op
-BenchmarkStore_DeleteWithoutTtl/Delete_key_salut-8        260808              4530 ns/op
-BenchmarkStore_DeleteWithoutTtl/Delete_key_bonjour-8              259333              4697 ns/op
-BenchmarkStore_DeleteWithoutTtl/Delete_key_hola-8                 253994              4579 ns/op
-BenchmarkStore_DeleteWithoutTtl/Delete_key_oi-8                   260127              4552 ns/op
-BenchmarkStore_DeleteWithoutTtl/Delete_key_mulimuta-8             259500              4551 ns/op
-BenchmarkStore_DeleteWithTtl/Delete_key_hey-8                     495697              3050 ns/op
-BenchmarkStore_DeleteWithTtl/Delete_key_hi-8                      265194              4796 ns/op
-BenchmarkStore_DeleteWithTtl/Delete_key_salut-8                   233242              4715 ns/op
-BenchmarkStore_DeleteWithTtl/Delete_key_bonjour-8                 261645              4521 ns/op
-BenchmarkStore_DeleteWithTtl/Delete_key_hola-8                    255002              4779 ns/op
-BenchmarkStore_DeleteWithTtl/Delete_key_oi-8                      247960              4761 ns/op
-BenchmarkStore_DeleteWithTtl/Delete_key_mulimuta-8                245869              4810 ns/op
-BenchmarkStore_GetWithoutTtl/Get_hey-8                           6655038               185.4 ns/op
-BenchmarkStore_GetWithoutTtl/Get_hi-8                            6674360               181.5 ns/op
-BenchmarkStore_GetWithoutTtl/Get_salut-8                         6404012               204.9 ns/op
-BenchmarkStore_GetWithoutTtl/Get_bonjour-8                       6227780               185.7 ns/op
-BenchmarkStore_GetWithoutTtl/Get_hola-8                          6207739               184.4 ns/op
-BenchmarkStore_GetWithoutTtl/Get_oi-8                            6102019               188.5 ns/op
-BenchmarkStore_GetWithoutTtl/Get_mulimuta-8                      6649304               184.0 ns/op
-BenchmarkStore_GetWithTtl/Get_hey-8                              4420294               273.9 ns/op
-BenchmarkStore_GetWithTtl/Get_hi-8                               4404975               268.1 ns/op
-BenchmarkStore_GetWithTtl/Get_salut-8                            3829527               280.7 ns/op
-BenchmarkStore_GetWithTtl/Get_bonjour-8                          4427978               268.8 ns/op
-BenchmarkStore_GetWithTtl/Get_hola-8                             4660736               258.8 ns/op
-BenchmarkStore_GetWithTtl/Get_oi-8                               4547602               265.8 ns/op
-BenchmarkStore_GetWithTtl/Get_mulimuta-8                         4750611               249.1 ns/op
-BenchmarkStore_SearchWithoutPagination/Search_(no_pagination)_f-8                  81596             14615 ns/op
-BenchmarkStore_SearchWithoutPagination/Search_(no_pagination)_fo-8                 71950             15022 ns/op
-BenchmarkStore_SearchWithoutPagination/Search_(no_pagination)_foo-8               110924             11228 ns/op
-BenchmarkStore_SearchWithoutPagination/Search_(no_pagination)_for-8               161625              7348 ns/op
-BenchmarkStore_SearchWithoutPagination/Search_(no_pagination)_b-8                 101258             11272 ns/op
-BenchmarkStore_SearchWithoutPagination/Search_(no_pagination)_ba-8                112938             11045 ns/op
-BenchmarkStore_SearchWithoutPagination/Search_(no_pagination)_bar-8               171814              7295 ns/op
-BenchmarkStore_SearchWithoutPagination/Search_(no_pagination)_ban-8               163743              7187 ns/op
-BenchmarkStore_SearchWithoutPagination/Search_(no_pagination)_pigg-8              234506              4902 ns/op
-BenchmarkStore_SearchWithoutPagination/Search_(no_pagination)_p-8                 178639              6935 ns/op
-BenchmarkStore_SearchWithoutPagination/Search_(no_pagination)_pi-8                180256              7168 ns/op
-BenchmarkStore_SearchWithoutPagination/Search_(no_pagination)_pig-8               167142              7267 ns/op
-BenchmarkStore_SearchWithPagination/Search_(paginated)_f-8                         86421             13569 ns/op
-BenchmarkStore_SearchWithPagination/Search_(paginated)_fo-8                        77089             13472 ns/op
-BenchmarkStore_SearchWithPagination/Search_(paginated)_foo-8                      128644              8989 ns/op
-BenchmarkStore_SearchWithPagination/Search_(paginated)_for-8                      258955              4672 ns/op
-BenchmarkStore_SearchWithPagination/Search_(paginated)_b-8                        139004              8836 ns/op
-BenchmarkStore_SearchWithPagination/Search_(paginated)_ba-8                       136581              8899 ns/op
-BenchmarkStore_SearchWithPagination/Search_(paginated)_bar-8                      245930              5010 ns/op
-BenchmarkStore_SearchWithPagination/Search_(paginated)_ban-8                      253870              4970 ns/op
-BenchmarkStore_SearchWithPagination/Search_(paginated)_pigg-8                     256216              4833 ns/op
-BenchmarkStore_SearchWithPagination/Search_(paginated)_p-8                        257278              4863 ns/op
-BenchmarkStore_SearchWithPagination/Search_(paginated)_pi-8                       254498              4831 ns/op
-BenchmarkStore_SearchWithPagination/Search_(paginated)_pig-8                      259162              4754 ns/op
-BenchmarkStore_SetWithoutTtl/Set_hey_English-8                                     52761             23906 ns/op
-BenchmarkStore_SetWithoutTtl/Set_hi_English-8                                      43544             28114 ns/op
-BenchmarkStore_SetWithoutTtl/Set_salut_French-8                                    35671             34184 ns/op
-BenchmarkStore_SetWithoutTtl/Set_bonjour_French-8                                  35151             33110 ns/op
-BenchmarkStore_SetWithoutTtl/Set_hola_Spanish-8                                    33321             36255 ns/op
-BenchmarkStore_SetWithoutTtl/Set_oi_Portuguese-8                                   49029             24633 ns/op
-BenchmarkStore_SetWithoutTtl/Set_mulimuta_Runyoro-8                                36476             32611 ns/op
-BenchmarkStore_SetWithTtl/Set_hey_English-8                                        51962             24385 ns/op
-BenchmarkStore_SetWithTtl/Set_hi_English-8                                         39193             28665 ns/op
-BenchmarkStore_SetWithTtl/Set_salut_French-8                                       33957             33743 ns/op
-BenchmarkStore_SetWithTtl/Set_bonjour_French-8                                     31314             35946 ns/op
-BenchmarkStore_SetWithTtl/Set_hola_Spanish-8                                       28106             40356 ns/op
-BenchmarkStore_SetWithTtl/Set_oi_Portuguese-8                                      43882             25837 ns/op
-BenchmarkStore_SetWithTtl/Set_mulimuta_Runyoro-8                                   36912             33885 ns/op
-PASS
-ok      github.com/sopherapps/go-scdb/scdb      100.150s
+BenchmarkStore_Clear/Clear-8                       44492             26389 ns/op
+BenchmarkStore_ClearWithSearch/ClearWithSearch-8                   17625             79099 ns/op
+BenchmarkStore_ClearWithTTL/Clear_with_ttl:_3600-8                 40906             29675 ns/op
+BenchmarkStore_ClearWithTTLAndSearch/ClearWithTTLAndSearch:_3600-8                 17416             69369 ns/op
+BenchmarkStore_Compact/Compact-8                                                      48          26330864 ns/op
+BenchmarkStore_CompactWithSearch/CompactWithSearch-8                                  50          24116051 ns/op
+BenchmarkStore_Delete/Delete_key_hey-8                                            531001              2348 ns/op
+BenchmarkStore_Delete/Delete_key_hi-8                                             281532              4377 ns/op
+BenchmarkStore_Delete/Delete_key_salut-8                                          253088              4677 ns/op
+BenchmarkStore_Delete/Delete_key_bonjour-8                                        252166              4530 ns/op
+BenchmarkStore_Delete/Delete_key_hola-8                                           261540              4618 ns/op
+BenchmarkStore_Delete/Delete_key_oi-8                                             258252              4607 ns/op
+BenchmarkStore_Delete/Delete_key_mulimuta-8                                       253100              4650 ns/op
+BenchmarkStore_DeleteWithTTL/DeleteWithTTL_hey-8                                  490236              2334 ns/op
+BenchmarkStore_DeleteWithTTL/DeleteWithTTL_hi-8                                   517951              4609 ns/op
+BenchmarkStore_DeleteWithTTL/DeleteWithTTL_salut-8                                253389              4791 ns/op
+BenchmarkStore_DeleteWithTTL/DeleteWithTTL_bonjour-8                              264606              4694 ns/op
+BenchmarkStore_DeleteWithTTL/DeleteWithTTL_hola-8                                 277142              4348 ns/op
+BenchmarkStore_DeleteWithTTL/DeleteWithTTL_oi-8                                   278862              4269 ns/op
+BenchmarkStore_DeleteWithTTL/DeleteWithTTL_mulimuta-8                             272217              4176 ns/op
+BenchmarkStore_DeleteWithSearch/DeleteWithSearch_hey-8                            491594              2088 ns/op
+BenchmarkStore_DeleteWithSearch/DeleteWithSearch_hi-8                             575847              4276 ns/op
+BenchmarkStore_DeleteWithSearch/DeleteWithSearch_salut-8                          199257              5350 ns/op
+BenchmarkStore_DeleteWithSearch/DeleteWithSearch_bonjour-8                        263126              4703 ns/op
+BenchmarkStore_DeleteWithSearch/DeleteWithSearch_hola-8                           242805              4708 ns/op
+BenchmarkStore_DeleteWithSearch/DeleteWithSearch_oi-8                             238066              5011 ns/op
+BenchmarkStore_DeleteWithSearch/DeleteWithSearch_mulimuta-8                       241566              4616 ns/op
+BenchmarkStore_DeleteWithTTLAndSearch/DeleteWithTTLAndSearchh_hey-8               507474              2225 ns/op
+BenchmarkStore_DeleteWithTTLAndSearch/DeleteWithTTLAndSearchh_hi-8                498913              2894 ns/op
+BenchmarkStore_DeleteWithTTLAndSearch/DeleteWithTTLAndSearchh_salut-8             196436              6546 ns/op
+BenchmarkStore_DeleteWithTTLAndSearch/DeleteWithTTLAndSearchh_bonjour-8           258450              4525 ns/op
+BenchmarkStore_DeleteWithTTLAndSearch/DeleteWithTTLAndSearchh_hola-8              268400              4410 ns/op
+BenchmarkStore_DeleteWithTTLAndSearch/DeleteWithTTLAndSearchh_oi-8                265454              4663 ns/op
+BenchmarkStore_DeleteWithTTLAndSearch/DeleteWithTTLAndSearchh_mulimuta-8          222576              5542 ns/op
+BenchmarkStore_Get/Get_hey-8                                                     5862396               176.0 ns/op
+BenchmarkStore_Get/Get_hi-8                                                      6947508               190.7 ns/op
+BenchmarkStore_Get/Get_salut-8                                                   6504044               178.1 ns/op
+BenchmarkStore_Get/Get_bonjour-8                                                 6779437               197.9 ns/op
+BenchmarkStore_Get/Get_hola-8                                                    6746191               169.1 ns/op
+BenchmarkStore_Get/Get_oi-8                                                      7118454               168.1 ns/op
+BenchmarkStore_Get/Get_mulimuta-8                                                6582776               175.6 ns/op
+BenchmarkStore_GetWithTtl/GetWithTTL_hey-8                                       4462608               266.7 ns/op
+BenchmarkStore_GetWithTtl/GetWithTTL_hi-8                                        4422298               265.1 ns/op
+BenchmarkStore_GetWithTtl/GetWithTTL_salut-8                                     4352011               257.2 ns/op
+BenchmarkStore_GetWithTtl/GetWithTTL_bonjour-8                                   4607902               256.0 ns/op
+BenchmarkStore_GetWithTtl/GetWithTTL_hola-8                                      4616398               250.1 ns/op
+BenchmarkStore_GetWithTtl/GetWithTTL_oi-8                                        4739011               253.0 ns/op
+BenchmarkStore_GetWithTtl/GetWithTTL_mulimuta-8                                  4577208               285.3 ns/op
+BenchmarkStore_GetWithSearch/GetWithSearch_hey-8                                 6936900               170.9 ns/op
+BenchmarkStore_GetWithSearch/GetWithSearch_hi-8                                  6987890               192.4 ns/op
+BenchmarkStore_GetWithSearch/GetWithSearch_salut-8                               5693048               187.9 ns/op
+BenchmarkStore_GetWithSearch/GetWithSearch_bonjour-8                             6073545               189.5 ns/op
+BenchmarkStore_GetWithSearch/GetWithSearch_hola-8                                7124277               191.0 ns/op
+BenchmarkStore_GetWithSearch/GetWithSearch_oi-8                                  6097592               190.6 ns/op
+BenchmarkStore_GetWithSearch/GetWithSearch_mulimuta-8                            6402308               184.8 ns/op
+BenchmarkStore_GetWithTTLAndSearch/GetWithTTLAndSearch_hey-8                     4462237               266.8 ns/op
+BenchmarkStore_GetWithTTLAndSearch/GetWithTTLAndSearch_hi-8                      4289282               256.6 ns/op
+BenchmarkStore_GetWithTTLAndSearch/GetWithTTLAndSearch_salut-8                   4569208               280.5 ns/op
+BenchmarkStore_GetWithTTLAndSearch/GetWithTTLAndSearch_bonjour-8                 4394884               280.5 ns/op
+BenchmarkStore_GetWithTTLAndSearch/GetWithTTLAndSearch_hola-8                    4255833               285.5 ns/op
+BenchmarkStore_GetWithTTLAndSearch/GetWithTTLAndSearch_oi-8                      4361965               269.2 ns/op
+BenchmarkStore_GetWithTTLAndSearch/GetWithTTLAndSearch_mulimuta-8                4150986               269.8 ns/op
+BenchmarkStore_SearchWithoutPagination/Search_(no_pagination)_f-8                  72859             16477 ns/op
+BenchmarkStore_SearchWithoutPagination/Search_(no_pagination)_fo-8                 74356             14790 ns/op
+BenchmarkStore_SearchWithoutPagination/Search_(no_pagination)_foo-8               110252             11103 ns/op
+BenchmarkStore_SearchWithoutPagination/Search_(no_pagination)_for-8               158568              7403 ns/op
+BenchmarkStore_SearchWithoutPagination/Search_(no_pagination)_b-8                 106458             11226 ns/op
+BenchmarkStore_SearchWithoutPagination/Search_(no_pagination)_ba-8                108511             11362 ns/op
+BenchmarkStore_SearchWithoutPagination/Search_(no_pagination)_bar-8               159764              6863 ns/op
+BenchmarkStore_SearchWithoutPagination/Search_(no_pagination)_ban-8               166546              6977 ns/op
+BenchmarkStore_SearchWithoutPagination/Search_(no_pagination)_pigg-8              241080              5049 ns/op
+BenchmarkStore_SearchWithoutPagination/Search_(no_pagination)_p-8                 164688              6837 ns/op
+BenchmarkStore_SearchWithoutPagination/Search_(no_pagination)_pi-8                170878              6839 ns/op
+BenchmarkStore_SearchWithoutPagination/Search_(no_pagination)_pig-8               171812              6744 ns/op
+BenchmarkStore_SearchWithPagination/Search_(paginated)_f-8                         93435             14183 ns/op
+BenchmarkStore_SearchWithPagination/Search_(paginated)_fo-8                        64582             15807 ns/op
+BenchmarkStore_SearchWithPagination/Search_(paginated)_foo-8                      117596              9124 ns/op
+BenchmarkStore_SearchWithPagination/Search_(paginated)_for-8                      251922              5399 ns/op
+BenchmarkStore_SearchWithPagination/Search_(paginated)_b-8                        129148              9753 ns/op
+BenchmarkStore_SearchWithPagination/Search_(paginated)_ba-8                       136021             10687 ns/op
+BenchmarkStore_SearchWithPagination/Search_(paginated)_bar-8                      240330              5207 ns/op
+BenchmarkStore_SearchWithPagination/Search_(paginated)_ban-8                      214779              5375 ns/op
+BenchmarkStore_SearchWithPagination/Search_(paginated)_pigg-8                     223549              5274 ns/op
+BenchmarkStore_SearchWithPagination/Search_(paginated)_p-8                        249134              5487 ns/op
+BenchmarkStore_SearchWithPagination/Search_(paginated)_pi-8                       222294              5169 ns/op
+BenchmarkStore_SearchWithPagination/Search_(paginated)_pig-8                      248499              5291 ns/op
+BenchmarkStore_Set/Set_hey_English-8                                              256216              7841 ns/op
+BenchmarkStore_Set/Set_hi_English-8                                               174416              7295 ns/op
+BenchmarkStore_Set/Set_salut_French-8                                             155991              7452 ns/op
+BenchmarkStore_Set/Set_bonjour_French-8                                           172024              7358 ns/op
+BenchmarkStore_Set/Set_hola_Spanish-8                                             173121              7262 ns/op
+BenchmarkStore_Set/Set_oi_Portuguese-8                                            153562              7789 ns/op
+BenchmarkStore_Set/Set_mulimuta_Runyoro-8                                         160923              7392 ns/op
+BenchmarkStore_SetWithTTL/SetWithTTL_hey_English-8                                245534              6131 ns/op
+BenchmarkStore_SetWithTTL/SetWithTTL_hi_English-8                                 168194              8055 ns/op
+BenchmarkStore_SetWithTTL/SetWithTTL_salut_French-8                               142149              7559 ns/op
+BenchmarkStore_SetWithTTL/SetWithTTL_bonjour_French-8                             150925              7472 ns/op
+BenchmarkStore_SetWithTTL/SetWithTTL_hola_Spanish-8                               164697              7438 ns/op
+BenchmarkStore_SetWithTTL/SetWithTTL_oi_Portuguese-8                              171195              7579 ns/op
+BenchmarkStore_SetWithTTL/SetWithTTL_mulimuta_Runyoro-8                           168396              6879 ns/op
+BenchmarkStore_SetWithSearch/SetWithSearch_hey_English-8                           53628             25591 ns/op
+BenchmarkStore_SetWithSearch/SetWithSearch_hi_English-8                            39859             30283 ns/op
+BenchmarkStore_SetWithSearch/SetWithSearch_salut_French-8                          35337             34117 ns/op
+BenchmarkStore_SetWithSearch/SetWithSearch_bonjour_French-8                        35120             33453 ns/op
+BenchmarkStore_SetWithSearch/SetWithSearch_hola_Spanish-8                          33634             37380 ns/op
+BenchmarkStore_SetWithSearch/SetWithSearch_oi_Portuguese-8                         45607             24459 ns/op
+BenchmarkStore_SetWithSearch/SetWithSearch_mulimuta_Runyoro-8                      37992             35116 ns/op
+BenchmarkStore_SetWithTTLAndSearch/SetWithTTLAndSearch_hey_English-8               47523             26086 ns/op
+BenchmarkStore_SetWithTTLAndSearch/SetWithTTLAndSearch_hi_English-8                38470             28093 ns/op
+BenchmarkStore_SetWithTTLAndSearch/SetWithTTLAndSearch_salut_French-8              38239             31343 ns/op
+BenchmarkStore_SetWithTTLAndSearch/SetWithTTLAndSearch_bonjour_French-8            36504             31324 ns/op
+BenchmarkStore_SetWithTTLAndSearch/SetWithTTLAndSearch_hola_Spanish-8              34225             35163 ns/op
+BenchmarkStore_SetWithTTLAndSearch/SetWithTTLAndSearch_oi_Portuguese-8             51085             23423 ns/op
+BenchmarkStore_SetWithTTLAndSearch/SetWithTTLAndSearch_mulimuta_Runyoro-8          38134             31272 ns/op
 ```
 
 ## Acknowledgements

--- a/examples/sample.go
+++ b/examples/sample.go
@@ -21,7 +21,6 @@ func main() {
 	var redundantBlocks uint16 = 1
 	var poolCapacity uint64 = 10
 	var compactionInterval uint32 = 1_800
-	var maxIndexKeyLen uint32 = 3
 
 	store, err := scdb.New(
 		"db",
@@ -29,7 +28,7 @@ func main() {
 		&redundantBlocks,
 		&poolCapacity,
 		&compactionInterval,
-		&maxIndexKeyLen)
+		true)
 	if err != nil {
 		log.Fatalf("error opening store: %s", err)
 	}

--- a/scdb/errors/errors.go
+++ b/scdb/errors/errors.go
@@ -31,3 +31,18 @@ func (ecs *ErrCollisionSaturation) Error() string {
 func NewErrCollisionSaturation(k []byte) *ErrCollisionSaturation {
 	return &ErrCollisionSaturation{fmt.Sprintf("no free slot for %s", k)}
 }
+
+// ErrNotSupported is the error when there is an attempt to
+// do an unsupported operation
+type ErrNotSupported struct {
+	op string
+}
+
+func (ens *ErrNotSupported) Error() string {
+	return fmt.Sprintf("%s not supported", ens.op)
+}
+
+// NewErrNotSupported creates a new ErrNotSupported
+func NewErrNotSupported(op string) *ErrNotSupported {
+	return &ErrNotSupported{op}
+}

--- a/scdb/internal/buffers/pool.go
+++ b/scdb/internal/buffers/pool.go
@@ -230,6 +230,13 @@ func (bp *BufferPool) CompactFile(searchIndex *inverted_index.InvertedIndex) err
 	numOfBlocks := int64(header.NumberOfIndexBlocks)
 	blockSize := int64(header.NetBlockSize)
 
+	if searchIndex != nil {
+		err = searchIndex.Clear()
+		if err != nil {
+			return err
+		}
+	}
+
 	for i := int64(0); i < numOfBlocks; i++ {
 		indexBlock, err := bp.readIndexBlock(i, blockSize)
 		if err != nil {
@@ -274,9 +281,11 @@ func (bp *BufferPool) CompactFile(searchIndex *inverted_index.InvertedIndex) err
 					}
 
 					// update search index
-					err = searchIndex.Add(kv.Key, newKvAddr, kv.Expiry)
-					if err != nil {
-						return err
+					if searchIndex != nil {
+						err = searchIndex.Add(kv.Key, newKvAddr, kv.Expiry)
+						if err != nil {
+							return err
+						}
 					}
 
 					// increment the new file offset

--- a/scdb/internal/buffers/pool_test.go
+++ b/scdb/internal/buffers/pool_test.go
@@ -440,10 +440,12 @@ func TestBufferPool_CompactFile(t *testing.T) {
 	indexFileName := "testdb_pool.iscdb"
 	defer func() {
 		_ = os.Remove(fileName)
+		_ = os.Remove(indexFileName)
 	}()
 
 	// pre-clean up for right results
 	_ = os.Remove(fileName)
+	_ = os.Remove(indexFileName)
 
 	futureTimestamp := uint64(time.Now().Unix() * 2)
 	neverExpires := values.NewKeyValueEntry([]byte("never_expires"), []byte("bar"), 0)
@@ -639,6 +641,9 @@ func TestBufferPool_GetValue(t *testing.T) {
 
 func TestBufferPool_GetManyKeyValues(t *testing.T) {
 	fileName := "testdb_pool.scdb"
+	defer func() {
+		_ = os.Remove(fileName)
+	}()
 
 	t.Run("GetManyKeyValuesReturnsTheKeyValuesForTheGivenAddresses", func(t *testing.T) {
 		defer func() {


### PR DESCRIPTION
### Why

Having the searching functionality enabled by default slows down all mutative operations i.e. `set`, `delete`, `clear`, `compact` by non-trivial margins. 
However, there are times when searching is not necessary. Why pay the cost for it when you don't need it?
Let's make it optional by replacing `maxIndexKeyLen` parameter of `scdb.New()` with `isSearchEnabled`.

Also, having the user decide the maximum size of the keys (`maxIndexKeyLen`) in the inverted index is unnecessary as for most usable cases, `3` seems enough.

### What was Done

- Changed the `scdb.New()` signature, replacing `maxIndexKeyLen` option with `isSearchEnabled`.
- Permanently set the maximum index key length to 3
- Changed benchmarks to compare operations when search is enabled to when search is disabled.